### PR TITLE
feat Modified to specification

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -130,6 +130,13 @@ paths:
           schema:
             type: string
             example: state
+        - name: nonce
+          in: query
+          required: false
+          description: nonce
+          schema:
+            type: string
+            example: nonce
       responses:
         '302':
           description: Found

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -200,38 +200,19 @@ paths:
         '500':
           description: Internal Server Error
   /op/token:
-    get:
+    post:
       tags:
         - OP
       summary: Token Request
       description: https://openid-foundation-japan.github.io/openid-connect-core-1_0.ja.html#TokenRequest
       operationId: opToken
-      parameters:
-        - name: grant_type
-          in: query
-          required: true
-          description: grant_type
-          schema:
-            type: string
-            enum:
-              - authorization_code
-              - refresh_token
-              - client_credentials
-              - password
-              - urn:ietf:params:oauth:grant-type:device_code
-        - name: code
-          in: query
-          required: true
-          description: code
-          schema:
-            type: string
-        - name: redirect_uri
-          in: query
-          required: true
-          description: http://localhost:1234/rp/callback
-          schema:
-            type: string
-            format: uri
+      requestBody:
+        description: opToken request body 
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/OPTokenRequestSchema'
       responses:
         '200':
           description: OK
@@ -384,6 +365,32 @@ components:
         - token_endpoint
         - userinfo_endpoint
         - revocation_endpoint
+    OPTokenRequestSchema:
+      type: object
+      properties:
+        grant_type:
+          type: string
+          enum:
+            - authorization_code
+            - refresh_token
+            - client_credentials
+            - password
+            - urn:ietf:params:oauth:grant-type:device_code
+          description: grant_type
+          example: authorization_code
+        code:
+          type: string
+          description: code
+          example: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+        redirect_uri:
+          type: string
+          description: http://localhost:1234/rp/callback
+          format: uri
+          example: http://localhost:1234/rp/callback
+      required:
+        - grant_type
+        - code
+        - redirect_uri
     OPTokenResponseSchema:
       type: object
       description: https://openid-foundation-japan.github.io/openid-connect-core-1_0.ja.html#TokenResponse

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"context"
-	"crypto/rand"
-	"crypto/rsa"
 	"errors"
 	"fmt"
 	"log"
@@ -44,8 +42,6 @@ func main() {
 
 	idToken := cache.New[model.IDToken]()
 
-	privateKey, _ := rsa.GenerateKey(rand.Reader, 4096)
-
 	idp := &idp.IdP{
 		UserCache: user,
 	}
@@ -68,7 +64,6 @@ func main() {
 		AccessTokenCache:     accessToken,
 		RefreshTokenCache:    refreshToken,
 		IDTokenCache:         idToken,
-		PrivateKey:           privateKey,
 		Issuer:               "http://localhost:1234",
 	}
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
 	"errors"
 	"fmt"
 	"log"
@@ -42,6 +44,8 @@ func main() {
 
 	idToken := cache.New[model.IDToken]()
 
+	privateKey, _ := rsa.GenerateKey(rand.Reader, 4096)
+
 	idp := &idp.IdP{
 		UserCache: user,
 	}
@@ -64,6 +68,8 @@ func main() {
 		AccessTokenCache:     accessToken,
 		RefreshTokenCache:    refreshToken,
 		IDTokenCache:         idToken,
+		PrivateKey:           privateKey,
+		Issuer:               "http://localhost:1234",
 	}
 
 	srv := NewServer("1234", NewHandler(idp, rp, op))
@@ -220,9 +226,8 @@ func (hdl *Handler) OpUserinfo(
 func (hdl *Handler) OpToken(
 	w http.ResponseWriter,
 	r *http.Request,
-	params openapi.OpTokenParams,
 ) {
-	hdl.OP.Token(w, r, params)
+	hdl.OP.Token(w, r)
 }
 
 func (hdl *Handler) RpLogin(

--- a/handler/op/op.go
+++ b/handler/op/op.go
@@ -1,6 +1,8 @@
 package op
 
 import (
+	"crypto/rsa"
+
 	"github.com/morning-night-dream/oidc/cache"
 	"github.com/morning-night-dream/oidc/model"
 	"github.com/morning-night-dream/oidc/pkg/openapi"
@@ -15,4 +17,6 @@ type OP struct {
 	AccessTokenCache     *cache.Cache[model.AccessToken]
 	RefreshTokenCache    *cache.Cache[model.RefreshToken]
 	IDTokenCache         *cache.Cache[model.IDToken]
+	PrivateKey           *rsa.PrivateKey
+	Issuer               string
 }

--- a/handler/op/op.go
+++ b/handler/op/op.go
@@ -1,8 +1,6 @@
 package op
 
 import (
-	"crypto/rsa"
-
 	"github.com/morning-night-dream/oidc/cache"
 	"github.com/morning-night-dream/oidc/model"
 	"github.com/morning-night-dream/oidc/pkg/openapi"
@@ -17,6 +15,5 @@ type OP struct {
 	AccessTokenCache     *cache.Cache[model.AccessToken]
 	RefreshTokenCache    *cache.Cache[model.RefreshToken]
 	IDTokenCache         *cache.Cache[model.IDToken]
-	PrivateKey           *rsa.PrivateKey
 	Issuer               string
 }

--- a/handler/op/token.go
+++ b/handler/op/token.go
@@ -72,7 +72,7 @@ func (op *OP) Token(
 	res := openapi.OPTokenResponseSchema{
 		TokenType:    "Bearer",
 		AccessToken:  at.JWT("sign"),
-		IdToken:      it.JWT(op.PrivateKey),
+		IdToken:      it.JWT("sign"),
 		RefreshToken: rt.Base64(),
 		ExpiresIn:    3600,
 	}

--- a/handler/op/token.go
+++ b/handler/op/token.go
@@ -29,6 +29,11 @@ func (op *OP) Token(
 		return
 	}
 
+	authReq, err := op.AuthorizeParamsCache.Get(code)
+	if err != nil {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	}
+
 	// ref. https://qiita.com/TakahikoKawasaki/items/970548727761f9e02bcd
 	// 1.3 hybrid type で実装してみる
 	// -> アクセストークンを revoke したいため
@@ -59,7 +64,7 @@ func (op *OP) Token(
 		op.Issuer,
 		user.ID,
 		op.AllowClientID,
-		"nonce",
+		*authReq.Nonce,
 		user.Username,
 	)
 

--- a/model/id_token.go
+++ b/model/id_token.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"crypto/rsa"
 	"fmt"
 	"time"
 
@@ -41,7 +42,7 @@ func GenerateIDToken(
 }
 
 func (it IDToken) JWT(
-	sign string,
+	sign *rsa.PrivateKey,
 ) string {
 	claims := jwt.MapClaims{
 		"iss":   it.Iss,
@@ -53,9 +54,9 @@ func (it IDToken) JWT(
 		"name":  it.Name,
 	}
 
-	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
 
-	str, _ := token.SignedString([]byte(sign))
+	str, _ := token.SignedString(sign)
 
 	return str
 }

--- a/model/id_token.go
+++ b/model/id_token.go
@@ -1,7 +1,6 @@
 package model
 
 import (
-	"crypto/rsa"
 	"fmt"
 	"time"
 
@@ -42,7 +41,7 @@ func GenerateIDToken(
 }
 
 func (it IDToken) JWT(
-	sign *rsa.PrivateKey,
+	sign string,
 ) string {
 	claims := jwt.MapClaims{
 		"iss":   it.Iss,
@@ -54,9 +53,9 @@ func (it IDToken) JWT(
 		"name":  it.Name,
 	}
 
-	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 
-	str, _ := token.SignedString(sign)
+	str, _ := token.SignedString([]byte(sign))
 
 	return str
 }

--- a/pkg/openapi/client.gen.go
+++ b/pkg/openapi/client.gen.go
@@ -114,8 +114,10 @@ type ClientInterface interface {
 	// OpLoginView request
 	OpLoginView(ctx context.Context, params *OpLoginViewParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// OpToken request
-	OpToken(ctx context.Context, params *OpTokenParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// OpToken request with any body
+	OpTokenWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	OpTokenWithFormdataBody(ctx context.Context, body OpTokenFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// OpUserinfo request
 	OpUserinfo(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -235,8 +237,20 @@ func (c *Client) OpLoginView(ctx context.Context, params *OpLoginViewParams, req
 	return c.Client.Do(req)
 }
 
-func (c *Client) OpToken(ctx context.Context, params *OpTokenParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewOpTokenRequest(c.Server, params)
+func (c *Client) OpTokenWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewOpTokenRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) OpTokenWithFormdataBody(ctx context.Context, body OpTokenFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewOpTokenRequestWithFormdataBody(c.Server, body)
 	if err != nil {
 		return nil, err
 	}
@@ -604,8 +618,19 @@ func NewOpLoginViewRequest(server string, params *OpLoginViewParams) (*http.Requ
 	return req, nil
 }
 
-// NewOpTokenRequest generates requests for OpToken
-func NewOpTokenRequest(server string, params *OpTokenParams) (*http.Request, error) {
+// NewOpTokenRequestWithFormdataBody calls the generic OpToken builder with application/x-www-form-urlencoded body
+func NewOpTokenRequestWithFormdataBody(server string, body OpTokenFormdataRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	bodyStr, err := runtime.MarshalForm(body, nil)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = strings.NewReader(bodyStr.Encode())
+	return NewOpTokenRequestWithBody(server, "application/x-www-form-urlencoded", bodyReader)
+}
+
+// NewOpTokenRequestWithBody generates requests for OpToken with any type of body
+func NewOpTokenRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -623,52 +648,12 @@ func NewOpTokenRequest(server string, params *OpTokenParams) (*http.Request, err
 		return nil, err
 	}
 
-	if params != nil {
-		queryValues := queryURL.Query()
-
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "grant_type", runtime.ParamLocationQuery, params.GrantType); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
-				}
-			}
-		}
-
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "code", runtime.ParamLocationQuery, params.Code); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
-				}
-			}
-		}
-
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "redirect_uri", runtime.ParamLocationQuery, params.RedirectUri); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
-				}
-			}
-		}
-
-		queryURL.RawQuery = queryValues.Encode()
-	}
-
-	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	req, err := http.NewRequest("POST", queryURL.String(), body)
 	if err != nil {
 		return nil, err
 	}
+
+	req.Header.Add("Content-Type", contentType)
 
 	return req, nil
 }
@@ -852,8 +837,10 @@ type ClientWithResponsesInterface interface {
 	// OpLoginView request
 	OpLoginViewWithResponse(ctx context.Context, params *OpLoginViewParams, reqEditors ...RequestEditorFn) (*OpLoginViewResponse, error)
 
-	// OpToken request
-	OpTokenWithResponse(ctx context.Context, params *OpTokenParams, reqEditors ...RequestEditorFn) (*OpTokenResponse, error)
+	// OpToken request with any body
+	OpTokenWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*OpTokenResponse, error)
+
+	OpTokenWithFormdataBodyWithResponse(ctx context.Context, body OpTokenFormdataRequestBody, reqEditors ...RequestEditorFn) (*OpTokenResponse, error)
 
 	// OpUserinfo request
 	OpUserinfoWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*OpUserinfoResponse, error)
@@ -1182,9 +1169,17 @@ func (c *ClientWithResponses) OpLoginViewWithResponse(ctx context.Context, param
 	return ParseOpLoginViewResponse(rsp)
 }
 
-// OpTokenWithResponse request returning *OpTokenResponse
-func (c *ClientWithResponses) OpTokenWithResponse(ctx context.Context, params *OpTokenParams, reqEditors ...RequestEditorFn) (*OpTokenResponse, error) {
-	rsp, err := c.OpToken(ctx, params, reqEditors...)
+// OpTokenWithBodyWithResponse request with arbitrary body returning *OpTokenResponse
+func (c *ClientWithResponses) OpTokenWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*OpTokenResponse, error) {
+	rsp, err := c.OpTokenWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseOpTokenResponse(rsp)
+}
+
+func (c *ClientWithResponses) OpTokenWithFormdataBodyWithResponse(ctx context.Context, body OpTokenFormdataRequestBody, reqEditors ...RequestEditorFn) (*OpTokenResponse, error) {
+	rsp, err := c.OpTokenWithFormdataBody(ctx, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/openapi/client.gen.go
+++ b/pkg/openapi/client.gen.go
@@ -490,6 +490,22 @@ func NewOpAuthorizeRequest(server string, params *OpAuthorizeParams) (*http.Requ
 
 		}
 
+		if params.Nonce != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "nonce", runtime.ParamLocationQuery, *params.Nonce); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
 		queryURL.RawQuery = queryValues.Encode()
 	}
 

--- a/pkg/openapi/server.gen.go
+++ b/pkg/openapi/server.gen.go
@@ -36,8 +36,8 @@ type ServerInterface interface {
 	// (GET /op/login/view)
 	OpLoginView(w http.ResponseWriter, r *http.Request, params OpLoginViewParams)
 	// Token Request
-	// (GET /op/token)
-	OpToken(w http.ResponseWriter, r *http.Request, params OpTokenParams)
+	// (POST /op/token)
+	OpToken(w http.ResponseWriter, r *http.Request)
 	// UserInfo Request
 	// (GET /op/userinfo)
 	OpUserinfo(w http.ResponseWriter, r *http.Request)
@@ -280,58 +280,8 @@ func (siw *ServerInterfaceWrapper) OpLoginView(w http.ResponseWriter, r *http.Re
 func (siw *ServerInterfaceWrapper) OpToken(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	var err error
-
-	// Parameter object where we will unmarshal all parameters from the context
-	var params OpTokenParams
-
-	// ------------- Required query parameter "grant_type" -------------
-
-	if paramValue := r.URL.Query().Get("grant_type"); paramValue != "" {
-
-	} else {
-		siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "grant_type"})
-		return
-	}
-
-	err = runtime.BindQueryParameter("form", true, true, "grant_type", r.URL.Query(), &params.GrantType)
-	if err != nil {
-		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "grant_type", Err: err})
-		return
-	}
-
-	// ------------- Required query parameter "code" -------------
-
-	if paramValue := r.URL.Query().Get("code"); paramValue != "" {
-
-	} else {
-		siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "code"})
-		return
-	}
-
-	err = runtime.BindQueryParameter("form", true, true, "code", r.URL.Query(), &params.Code)
-	if err != nil {
-		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "code", Err: err})
-		return
-	}
-
-	// ------------- Required query parameter "redirect_uri" -------------
-
-	if paramValue := r.URL.Query().Get("redirect_uri"); paramValue != "" {
-
-	} else {
-		siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "redirect_uri"})
-		return
-	}
-
-	err = runtime.BindQueryParameter("form", true, true, "redirect_uri", r.URL.Query(), &params.RedirectUri)
-	if err != nil {
-		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "redirect_uri", Err: err})
-		return
-	}
-
 	var handler http.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.OpToken(w, r, params)
+		siw.Handler.OpToken(w, r)
 	})
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -558,7 +508,7 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 		r.Get(options.BaseURL+"/op/login/view", wrapper.OpLoginView)
 	})
 	r.Group(func(r chi.Router) {
-		r.Get(options.BaseURL+"/op/token", wrapper.OpToken)
+		r.Post(options.BaseURL+"/op/token", wrapper.OpToken)
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/op/userinfo", wrapper.OpUserinfo)

--- a/pkg/openapi/server.gen.go
+++ b/pkg/openapi/server.gen.go
@@ -180,6 +180,14 @@ func (siw *ServerInterfaceWrapper) OpAuthorize(w http.ResponseWriter, r *http.Re
 		return
 	}
 
+	// ------------- Optional query parameter "nonce" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "nonce", r.URL.Query(), &params.Nonce)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "nonce", Err: err})
+		return
+	}
+
 	var handler http.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.OpAuthorize(w, r, params)
 	})

--- a/pkg/openapi/types.gen.go
+++ b/pkg/openapi/types.gen.go
@@ -131,6 +131,9 @@ type OpAuthorizeParams struct {
 
 	// State state
 	State *string `form:"state,omitempty" json:"state,omitempty"`
+
+	// Nonce nonce
+	Nonce *string `form:"nonce,omitempty" json:"nonce,omitempty"`
 }
 
 // OpAuthorizeParamsResponseType defines parameters for OpAuthorize.

--- a/pkg/openapi/types.gen.go
+++ b/pkg/openapi/types.gen.go
@@ -7,6 +7,15 @@ const (
 	BearerScopes = "Bearer.Scopes"
 )
 
+// Defines values for OPTokenRequestSchemaGrantType.
+const (
+	AuthorizationCode                     OPTokenRequestSchemaGrantType = "authorization_code"
+	ClientCredentials                     OPTokenRequestSchemaGrantType = "client_credentials"
+	Password                              OPTokenRequestSchemaGrantType = "password"
+	RefreshToken                          OPTokenRequestSchemaGrantType = "refresh_token"
+	UrnIetfParamsOauthGrantTypeDeviceCode OPTokenRequestSchemaGrantType = "urn:ietf:params:oauth:grant-type:device_code"
+)
+
 // Defines values for OpAuthorizeParamsResponseType.
 const (
 	Code             OpAuthorizeParamsResponseType = "code"
@@ -26,15 +35,6 @@ const (
 	Openid        OpAuthorizeParamsScope = "openid"
 	Phone         OpAuthorizeParamsScope = "phone"
 	Profile       OpAuthorizeParamsScope = "profile"
-)
-
-// Defines values for OpTokenParamsGrantType.
-const (
-	AuthorizationCode                     OpTokenParamsGrantType = "authorization_code"
-	ClientCredentials                     OpTokenParamsGrantType = "client_credentials"
-	Password                              OpTokenParamsGrantType = "password"
-	RefreshToken                          OpTokenParamsGrantType = "refresh_token"
-	UrnIetfParamsOauthGrantTypeDeviceCode OpTokenParamsGrantType = "urn:ietf:params:oauth:grant-type:device_code"
 )
 
 // IdPSigninRequestSchema defines model for IdPSigninRequestSchema.
@@ -72,6 +72,21 @@ type OPOpenIDConfigurationResponseSchema struct {
 	// UserinfoEndpoint http://localhost:1234/op/userinfo
 	UserinfoEndpoint string `json:"userinfo_endpoint"`
 }
+
+// OPTokenRequestSchema defines model for OPTokenRequestSchema.
+type OPTokenRequestSchema struct {
+	// Code code
+	Code string `json:"code"`
+
+	// GrantType grant_type
+	GrantType OPTokenRequestSchemaGrantType `json:"grant_type"`
+
+	// RedirectUri http://localhost:1234/rp/callback
+	RedirectUri string `json:"redirect_uri"`
+}
+
+// OPTokenRequestSchemaGrantType grant_type
+type OPTokenRequestSchemaGrantType string
 
 // OPTokenResponseSchema https://openid-foundation-japan.github.io/openid-connect-core-1_0.ja.html#TokenResponse
 type OPTokenResponseSchema struct {
@@ -136,21 +151,6 @@ type OpLoginViewParams struct {
 	AuthRequestId string `form:"auth_request_id" json:"auth_request_id"`
 }
 
-// OpTokenParams defines parameters for OpToken.
-type OpTokenParams struct {
-	// GrantType grant_type
-	GrantType OpTokenParamsGrantType `form:"grant_type" json:"grant_type"`
-
-	// Code code
-	Code string `form:"code" json:"code"`
-
-	// RedirectUri http://localhost:1234/rp/callback
-	RedirectUri string `form:"redirect_uri" json:"redirect_uri"`
-}
-
-// OpTokenParamsGrantType defines parameters for OpToken.
-type OpTokenParamsGrantType string
-
 // RpCallbackParams defines parameters for RpCallback.
 type RpCallbackParams struct {
 	// Code code
@@ -165,3 +165,6 @@ type IdpSigninJSONRequestBody = IdPSigninRequestSchema
 
 // IdpSignupJSONRequestBody defines body for IdpSignup for application/json ContentType.
 type IdpSignupJSONRequestBody = IdPSignupRequestSchema
+
+// OpTokenFormdataRequestBody defines body for OpToken for application/x-www-form-urlencoded ContentType.
+type OpTokenFormdataRequestBody = OPTokenRequestSchema


### PR DESCRIPTION
- token endpointはGETではなくPOST

> [OAuth 2.0](https://openid-foundation-japan.github.io/openid-connect-core-1_0.ja.html#RFC6749) [RFC6749] の Section 4.1.3 に記載の通り, Client は, HTTP POST メソッドと [Section 13.2](https://openid-foundation-japan.github.io/openid-connect-core-1_0.ja.html#FormSerialization) による Form Serialization を用いて, Token Endpoint にパラメータを送信する.

- nonceはクライアントから送られたものを使用する